### PR TITLE
Upload pysubnettree to pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include COPYING
+include CHANGES
+include Makefile
+include VERSION
+include patricia.h
+include SubnetTree.h
+include test.py

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,6 @@ clean:
 	rm -rf $(CLEAN)
 
 dist:
-	@install -d $(BUILD)
-	@rm -rf $(BUILD)/$(TGZ)
-	@mkdir $(BUILD)/$(TGZ)
-	@cp -rp $(DISTFILES) $(BUILD)/$(TGZ)
-	cd $(BUILD) && tar czvf $(TGZ).tgz $(TGZ)
-	@rm -rf $(BUILD)/$(TGZ)
-	@echo "Package: $(BUILD)/$(TGZ).tgz"
+	@python setup.py sdist
+	@echo $<
 
-distclean:
-	rm -rf $(BUILD)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ import os
 cflags = os.environ.get("CFLAGS", "")
 os.environ["CFLAGS"] = cflags + " -fno-strict-aliasing"
 
-from distutils.core import setup, Extension
+from setuptools import setup
+from distutils.core import Extension
 
 setup(name="pysubnettree",
     version="0.22", # Filled in automatically.
@@ -14,7 +15,9 @@ setup(name="pysubnettree",
     license="BSD",
     py_modules=['SubnetTree'],
     ext_modules = [
-        Extension("_SubnetTree", ["SubnetTree.cc", "patricia.c", "SubnetTree_wrap.cc"]),
+        Extension("_SubnetTree",
+            sources=["SubnetTree.cc", "patricia.c", "SubnetTree_wrap.cc"],
+            depends=["SubnetTree.h", "patricia.h"]),
         ]
 )
 


### PR DESCRIPTION
It would be really awesome if pysubnettree were packaged on pypi.  Other python libraries could depend on it and have it automatically installed.  I modified the build code so that it will work with setuptools.  Once you're set up on pypi all you need to do is:

```
python setup.py sdist upload
```

You might also want to fill out a few more metadata fields in setup.py.
