### PR TITLE
Fix extension for stricter unicode validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   Run-BTest:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [macos-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/SubnetTree_wrap.cc
+++ b/SubnetTree_wrap.cc
@@ -1632,14 +1632,6 @@ SwigPyObject_repr(SwigPyObject *v, PyObject *args)
   return repr;  
 }
 
-/* We need a version taking two PyObject* parameters so it's a valid
- * PyCFunction to use in swigobject_methods[]. */
-SWIGRUNTIME PyObject *
-SwigPyObject_repr2(PyObject *v, PyObject *SWIGUNUSEDPARM(args))
-{
-  return SwigPyObject_repr((SwigPyObject*)v);
-}
-
 SWIGRUNTIME int
 SwigPyObject_compare(SwigPyObject *v, SwigPyObject *w)
 {
@@ -1769,7 +1761,11 @@ SwigPyObject_append(PyObject* v, PyObject* next)
 }
 
 SWIGRUNTIME PyObject* 
+#ifdef METH_NOARGS
+SwigPyObject_next(PyObject* v)
+#else
 SwigPyObject_next(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
+#endif
 {
   SwigPyObject *sobj = (SwigPyObject *) v;
   if (sobj->next) {    
@@ -1803,20 +1799,6 @@ SwigPyObject_acquire(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
   sobj->own = SWIG_POINTER_OWN;
   return SWIG_Py_Void();
 }
-
-#ifdef METH_NOARGS
-static PyObject*
-SwigPyObject_disown2(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
-{
-  return SwigPyObject_disown(v);
-}
-
-static PyObject*
-SwigPyObject_acquire2(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
-{
-  return SwigPyObject_acquire(v);
-}
-#endif
 
 SWIGINTERN PyObject*
 SwigPyObject_own(PyObject *v, PyObject *args)
@@ -1858,12 +1840,12 @@ SwigPyObject_own(PyObject *v, PyObject *args)
 #ifdef METH_O
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)SwigPyObject_disown2, METH_NOARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)SwigPyObject_acquire2,METH_NOARGS,  (char *)"acquires ownership of the pointer"},
+  {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"acquires ownership of the pointer"},
   {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
   {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_O,       (char *)"appends another 'this' object"},
   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr2,   METH_NOARGS,  (char *)"returns object representation"},
+  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #else
@@ -1874,7 +1856,7 @@ swigobject_methods[] = {
   {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
   {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_VARARGS,  (char *)"returns object representation"},
+  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #endif
@@ -3543,7 +3525,7 @@ SWIGINTERN PyObject *SubnetTree___getitem__(SubnetTree *self,char *cidr,int size
 
            PyObject* data = self->lookup(cidr, size);
            if ( ! data ) {
-               PyErr_SetString(PyExc_KeyError, cidr);
+               PyErr_SetObject(PyExc_KeyError, PyBytes_FromStringAndSize(cidr, size));
                return 0;
            }
 
@@ -4934,27 +4916,27 @@ SWIGINTERN PyObject *SubnetTree_swigregister(PyObject *SWIGUNUSEDPARM(self), PyO
 }
 
 static PyMethodDef SwigMethods[] = {
-	 { "SWIG_PyInstanceMethod_New", SWIG_PyInstanceMethod_New, METH_O, NULL},
-	 { "inx_addr_sin_set", _wrap_inx_addr_sin_set, METH_VARARGS, NULL},
-	 { "inx_addr_sin_get", _wrap_inx_addr_sin_get, METH_VARARGS, NULL},
-	 { "inx_addr_sin6_set", _wrap_inx_addr_sin6_set, METH_VARARGS, NULL},
-	 { "inx_addr_sin6_get", _wrap_inx_addr_sin6_get, METH_VARARGS, NULL},
-	 { "new_inx_addr", _wrap_new_inx_addr, METH_VARARGS, NULL},
-	 { "delete_inx_addr", _wrap_delete_inx_addr, METH_VARARGS, NULL},
-	 { "inx_addr_swigregister", inx_addr_swigregister, METH_VARARGS, NULL},
-	 { "new_SubnetTree", _wrap_new_SubnetTree, METH_VARARGS, NULL},
-	 { "delete_SubnetTree", _wrap_delete_SubnetTree, METH_VARARGS, NULL},
-	 { "SubnetTree_insert", _wrap_SubnetTree_insert, METH_VARARGS, NULL},
-	 { "SubnetTree_remove", _wrap_SubnetTree_remove, METH_VARARGS, NULL},
-	 { "SubnetTree_lookup", _wrap_SubnetTree_lookup, METH_VARARGS, NULL},
-	 { "SubnetTree_prefixes", _wrap_SubnetTree_prefixes, METH_VARARGS, NULL},
-	 { "SubnetTree_get_binary_lookup_mode", _wrap_SubnetTree_get_binary_lookup_mode, METH_VARARGS, NULL},
-	 { "SubnetTree_set_binary_lookup_mode", _wrap_SubnetTree_set_binary_lookup_mode, METH_VARARGS, NULL},
-	 { "SubnetTree___contains__", _wrap_SubnetTree___contains__, METH_VARARGS, NULL},
-	 { "SubnetTree___getitem__", _wrap_SubnetTree___getitem__, METH_VARARGS, NULL},
-	 { "SubnetTree___setitem__", _wrap_SubnetTree___setitem__, METH_VARARGS, NULL},
-	 { "SubnetTree___delitem__", _wrap_SubnetTree___delitem__, METH_VARARGS, NULL},
-	 { "SubnetTree_swigregister", SubnetTree_swigregister, METH_VARARGS, NULL},
+	 { (char *)"SWIG_PyInstanceMethod_New", (PyCFunction)SWIG_PyInstanceMethod_New, METH_O, NULL},
+	 { (char *)"inx_addr_sin_set", _wrap_inx_addr_sin_set, METH_VARARGS, NULL},
+	 { (char *)"inx_addr_sin_get", _wrap_inx_addr_sin_get, METH_VARARGS, NULL},
+	 { (char *)"inx_addr_sin6_set", _wrap_inx_addr_sin6_set, METH_VARARGS, NULL},
+	 { (char *)"inx_addr_sin6_get", _wrap_inx_addr_sin6_get, METH_VARARGS, NULL},
+	 { (char *)"new_inx_addr", _wrap_new_inx_addr, METH_VARARGS, NULL},
+	 { (char *)"delete_inx_addr", _wrap_delete_inx_addr, METH_VARARGS, NULL},
+	 { (char *)"inx_addr_swigregister", inx_addr_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_SubnetTree", _wrap_new_SubnetTree, METH_VARARGS, NULL},
+	 { (char *)"delete_SubnetTree", _wrap_delete_SubnetTree, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree_insert", _wrap_SubnetTree_insert, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree_remove", _wrap_SubnetTree_remove, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree_lookup", _wrap_SubnetTree_lookup, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree_prefixes", _wrap_SubnetTree_prefixes, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree_get_binary_lookup_mode", _wrap_SubnetTree_get_binary_lookup_mode, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree_set_binary_lookup_mode", _wrap_SubnetTree_set_binary_lookup_mode, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree___contains__", _wrap_SubnetTree___contains__, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree___getitem__", _wrap_SubnetTree___getitem__, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree___setitem__", _wrap_SubnetTree___setitem__, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree___delitem__", _wrap_SubnetTree___delitem__, METH_VARARGS, NULL},
+	 { (char *)"SubnetTree_swigregister", SubnetTree_swigregister, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }
 };
 
@@ -5527,9 +5509,9 @@ extern "C" {
             char *ndoc = (char*)malloc(ldoc + lptr + 10);
             if (ndoc) {
               char *buff = ndoc;
-              memcpy(buff, methods[i].ml_doc, ldoc);
+              strncpy(buff, methods[i].ml_doc, ldoc);
               buff += ldoc;
-              memcpy(buff, "swig_ptr: ", 10);
+              strncpy(buff, "swig_ptr: ", 10);
               buff += 10;
               SWIG_PackVoidPtr(buff, ptr, ty->name, lptr);
               methods[i].ml_doc = ndoc;
@@ -5591,8 +5573,8 @@ SWIG_init(void) {
     (char *)"this", &SwigPyBuiltin_ThisClosure, NULL, NULL, NULL
   };
   static SwigPyGetSet thisown_getset_closure = {
-    SwigPyObject_own,
-    SwigPyObject_own
+    (PyCFunction) SwigPyObject_own,
+    (PyCFunction) SwigPyObject_own
   };
   static PyGetSetDef thisown_getset_def = {
     (char *)"thisown", SwigPyBuiltin_GetterClosure, SwigPyBuiltin_SetterClosure, NULL, &thisown_getset_closure

--- a/include/SubnetTree.h
+++ b/include/SubnetTree.h
@@ -147,7 +147,7 @@ public:
 
            PyObject* data = self->lookup(cidr, size);
            if ( ! data ) {
-               PyErr_SetString(PyExc_KeyError, cidr);
+               PyErr_SetObject(PyExc_KeyError, PyBytes_FromStringAndSize(cidr, size));
                return 0;
            }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = [
+    "setuptools",
+]
+
+[project]
+name = "pysubnettree"
+dynamic = ["version"]
+description = "Map subnets in CIDR notation to Python objects"
+readme = "README"
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Environment :: Console',
+    'License :: OSI Approved :: BSD License',
+    'Operating System :: POSIX :: Linux',
+    'Operating System :: POSIX :: BSD :: FreeBSD',
+    'Operating System :: MacOS :: MacOS X',
+    'Programming Language :: Python :: 3',
+    'Topic :: System :: Networking',
+    'Topic :: Utilities',
+]
+
+[project.license]
+text = "BSD"
+
+[[project.maintainers]]
+name = "The Zeek Project"
+email = "info@zeek.org"

--- a/setup.py
+++ b/setup.py
@@ -9,22 +9,8 @@ os.environ["CFLAGS"] = cflags + " -fno-strict-aliasing"
 from setuptools import setup
 from distutils.core import Extension
 
-description = """
-The PySubnetTree package provides a Python data structure SubnetTree
-that maps subnets given in CIDR notation (incl. corresponding IPv6
-versions) to Python objects. Lookups are performed by longest-prefix
-matching.
-"""
-
-with open('README') as file:
-    long_description = file.read()
-
-setup(name="pysubnettree",
+setup(
     version="0.37", # Filled in automatically.
-    maintainer="The Zeek Project",
-    maintainer_email="info@zeek.org",
-    license="BSD",
-    description=description,
     py_modules=['SubnetTree'],
     url="https://github.com/zeek/pysubnettree",
     ext_modules = [
@@ -33,15 +19,4 @@ setup(name="pysubnettree",
             depends=["include/SubnetTree.h", "include/patricia.h"],
             include_dirs=["include/"])
         ],
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: POSIX :: BSD :: FreeBSD',
-        'Operating System :: MacOS :: MacOS X',
-        'Programming Language :: Python :: 3',
-        'Topic :: System :: Networking',
-        'Topic :: Utilities',
-    ],
 )

--- a/testing/pysubnettree/lookup.test
+++ b/testing/pysubnettree/lookup.test
@@ -40,8 +40,11 @@ def do_tests(binarymode):
     try:
         if t[v4("1.3.3.255")]:  pass
         testcase(False, "lookup should throw exception")
-    except KeyError:
-        pass
+    except KeyError as e:
+        # We expect a `KeyError` which reports the key. Since above address
+        # encodes to invalid unicode we'd expect to see the raw bytes as error
+        # message in binary mode.
+        assert str(e) == r"b'\x01\x03\x03\xff'" if binarymode else r"b'1.3.3.255'"
 
     try:
         if t[v6("1:3:3::3")]:  pass


### PR DESCRIPTION
This fixes our extension module for python/cpython#105375 which made unicode validation stricter (appeared e.g., in python-3.11.9).