### PR TITLE
Use SPDX license expression in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools"]
 name = "pysubnettree"
 description = "Map subnets in CIDR notation to Python objects"
 dynamic = ["version"]
-license = { text = "3-clause BSD License" }
+license = "BSD-3-Clause"
 readme = {file = "README", content-type = "text/x-rst"}
 
 # We would like to include the README here to be rendered on pypi
@@ -18,7 +18,6 @@ requires-python = ">=3.10"
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',
-    'License :: OSI Approved :: BSD License',
     'Operating System :: POSIX :: Linux',
     'Operating System :: POSIX :: BSD :: FreeBSD',
     'Operating System :: MacOS :: MacOS X',


### PR DESCRIPTION
Replace the deprecated `project.license` table format with a SPDX
license expression string ("BSD-3-Clause") and remove the deprecated
`License :: OSI Approved :: BSD License` classifier, as required by
setuptools>=77.0.0.
